### PR TITLE
Bump next 15.5.7 -> 15.5.9 for RSC security advisory

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "@react-email/render": "^1.2.3",
     "gray-matter": "^4.0.3",
     "lucide-react": "^0.544.0",
-    "next": "15.5.7",
+    "next": "15.5.9",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "resend": "^6.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -561,10 +561,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/env@npm:15.5.7":
-  version: 15.5.7
-  resolution: "@next/env@npm:15.5.7"
-  checksum: 10c0/f92d99e5fa3516c6b7699abafd9bd813f5c1889dd257ab098f1b71f93137f5e4f49792e22f6dddf8a59efcb134e8e84277c983ff88607b2a42aac651bfde78ea
+"@next/env@npm:15.5.9":
+  version: 15.5.9
+  resolution: "@next/env@npm:15.5.9"
+  checksum: 10c0/92c4e29d81a8e78c33c2da179648a4f478a9a6852966192e079007b19ec9955e72530d5ca7df55ea0efeccbf5b1c9d0efcaf80433e26af89c6478193e1d088f1
   languageName: node
   linkType: hard
 
@@ -1894,7 +1894,7 @@ __metadata:
     eslint-config-next: "npm:15.5.3"
     gray-matter: "npm:^4.0.3"
     lucide-react: "npm:^0.544.0"
-    next: "npm:15.5.7"
+    next: "npm:15.5.9"
     react: "npm:19.1.0"
     react-dom: "npm:19.1.0"
     resend: "npm:^6.1.0"
@@ -4715,11 +4715,11 @@ __metadata:
   languageName: node
   linkType: hard
 
-"next@npm:15.5.7":
-  version: 15.5.7
-  resolution: "next@npm:15.5.7"
+"next@npm:15.5.9":
+  version: 15.5.9
+  resolution: "next@npm:15.5.9"
   dependencies:
-    "@next/env": "npm:15.5.7"
+    "@next/env": "npm:15.5.9"
     "@next/swc-darwin-arm64": "npm:15.5.7"
     "@next/swc-darwin-x64": "npm:15.5.7"
     "@next/swc-linux-arm64-gnu": "npm:15.5.7"
@@ -4770,7 +4770,7 @@ __metadata:
       optional: true
   bin:
     next: dist/bin/next
-  checksum: 10c0/baf5b9f42416c478702b3894479b3d7862bc4abf18afe0e43b7fc7ed35567b8dc6cb76cd94906505bab9013cb8d0f3370cdc0451c01ec15ae5a638d37b5ba7c7
+  checksum: 10c0/6a120afbc45b96aa14debba6375602d6319093af4e3e8c648cf22b12ffb9db016c889df5e764cf5e0aa414ad60505db4e2095624a19f4b71316561076158651a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Patches CVE-2025-55183 (Server Function source-code exposure) and CVE-2025-55184 / CVE-2025-67779 (App Router RSC denial of service). See https://nextjs.org/blog/security-update-2025-12-11.